### PR TITLE
single-pool: update security.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7546,7 +7546,7 @@ dependencies = [
 
 [[package]]
 name = "spl-single-pool"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "approx",
  "arrayref",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-single-pool"
-version = "1.0.1"
+version = "1.0.2"
 description = "Solana Program Library Single-Validator Stake Pool"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/single-pool"

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -30,13 +30,11 @@ security_txt! {
     // Required fields
     name: "SPL Single-Validator Stake Pool",
     project_url: "https://spl.solana.com/single-pool",
-    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://discord.gg/solana",
+    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@anza.xyz,discord:https://discord.gg/solana",
     policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
 
     // Optional Fields
     preferred_languages: "en",
-    source_code: "https://github.com/solana-labs/solana-program-library/tree/master/single-pool/program",
-    source_revision: "ef44df985e76a697ee9a8aabb3a223610e4cf1dc",
-    source_release: "single-pool-v1.0.0",
-    auditors: "https://github.com/solana-labs/security-audits#single-stake-pool"
+    source_code: "https://github.com/solana-program/single-pool/tree/main/program",
+    auditors: "https://spl.solana.com/single-pool#security-audits"
 }


### PR DESCRIPTION
as we are planning to deploy, update the contact email to anza and some of the other refs from solana labs. i left the security advisory and policy as-is, since we still manage that repo and dont have existing equivalents yet. also removed version and commit hash because they are problematic to (or for commit hash literally impossible) to keep up to date