### PR TITLE
js: fix initialize to deposit 1sol

### DIFF
--- a/clients/js-legacy/tests/transactions.test.ts
+++ b/clients/js-legacy/tests/transactions.test.ts
@@ -37,6 +37,7 @@ const voteAccount = {
 };
 
 const SLOTS_PER_EPOCH: bigint = 432000n;
+const LAMPORTS_PER_SOL: number = 1_000_000_000;
 
 class BanksConnection {
   constructor(client: BanksClient, payer: Keypair) {
@@ -109,6 +110,10 @@ async function startWithContext(authorizedWithdrawer?: PublicKey) {
         },
       },
     ],
+    undefined,
+    undefined,
+    // stake_raise_minimum_delegation_to_1_sol::id()
+    [new PublicKey('9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i')],
   );
 }
 
@@ -245,7 +250,11 @@ test('deposit', async (t) => {
   const stakeRent = await connection.getMinimumBalanceForRentExemption(StakeProgram.space);
   const minimumDelegation = (await connection.getStakeMinimumDelegation()).value;
   const poolStakeAccount = await client.getAccount(poolStakeAddress);
-  t.is(poolStakeAccount.lamports, minimumDelegation * 2 + stakeRent, 'stake has been deposited');
+  t.is(
+    poolStakeAccount.lamports,
+    LAMPORTS_PER_SOL + minimumDelegation + stakeRent,
+    'stake has been deposited',
+  );
 });
 
 test('deposit from default', async (t) => {
@@ -286,7 +295,11 @@ test('deposit from default', async (t) => {
 
   const stakeRent = await connection.getMinimumBalanceForRentExemption(StakeProgram.space);
   const poolStakeAccount = await client.getAccount(poolStakeAddress);
-  t.is(poolStakeAccount.lamports, minimumDelegation * 2 + stakeRent, 'stake has been deposited');
+  t.is(
+    poolStakeAccount.lamports,
+    LAMPORTS_PER_SOL + minimumDelegation + stakeRent,
+    'stake has been deposited',
+  );
 });
 
 test('withdraw', async (t) => {

--- a/clients/js/src/transactions.ts
+++ b/clients/js/src/transactions.ts
@@ -91,7 +91,9 @@ export async function initializeTransaction(
     rpc.getMinimumBalanceForRentExemption(MINT_SIZE).send(),
     rpc.getStakeMinimumDelegation().send(),
   ]);
-  const minimumDelegation = minimumDelegationObj.value;
+  const lamportsPerSol = 1_000_000_000n;
+  const minimumPoolBalance =
+    minimumDelegationObj.value > lamportsPerSol ? minimumDelegationObj.value : lamportsPerSol;
 
   transaction = appendTransactionMessageInstruction(
     SystemInstruction.transfer({
@@ -106,7 +108,7 @@ export async function initializeTransaction(
     SystemInstruction.transfer({
       from: payer,
       to: stake,
-      lamports: stakeRent + minimumDelegation,
+      lamports: stakeRent + minimumPoolBalance,
     }),
     transaction,
   );


### PR DESCRIPTION
instead of refactoring all the tests to do something like `test_case` with both feature states, i just disabled the feature. this basically cannot fail if the minimum became 1sol because we hardcode 1sol. we would only need to do the gruntwork if the minimum was increased again, to _more_ than 1sol

note this was reported as an issue with `deposit` but it is actually just `initialize`. deposits of any size are fine, the program merely enforces that the pool has a whole must have at least 1sol

i also just merged a pr for cli tests to test against a validator with the 1lamp minimum, cli worked fine with no changes