### PR TITLE
program: rename `minimum_delegation` to `minimum_pool_balance`

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -126,7 +126,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         &vote_account_address,
         &payer.pubkey(),
         &quarantine::get_rent(config).await?,
-        quarantine::get_minimum_delegation(config).await?,
+        quarantine::get_minimum_pool_balance(config).await?,
     );
 
     // get rid of the CreateMetadata instruction if desired, eg if mpl breaks compat
@@ -820,7 +820,7 @@ async fn get_pool_display(
     let pool_stake_address = find_pool_stake_address(&spl_single_pool::id(), &pool_address);
     let available_stake =
         if let Some((_, stake)) = quarantine::get_stake_info(config, &pool_stake_address).await? {
-            stake.delegation.stake - quarantine::get_minimum_delegation(config).await?
+            stake.delegation.stake - quarantine::get_minimum_pool_balance(config).await?
         } else {
             unreachable!()
         };

--- a/clients/cli/src/quarantine.rs
+++ b/clients/cli/src/quarantine.rs
@@ -27,7 +27,7 @@ pub async fn get_rent(config: &Config) -> Result<Rent, Error> {
     Ok(rent)
 }
 
-pub async fn get_minimum_delegation(config: &Config) -> Result<u64, Error> {
+pub async fn get_minimum_pool_balance(config: &Config) -> Result<u64, Error> {
     Ok(std::cmp::max(
         config.rpc_client.get_stake_minimum_delegation().await?,
         LAMPORTS_PER_SOL,

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -56,7 +56,7 @@ pub enum SinglePoolError {
     // 10
     /// Not enough stake to cover the provided quantity of pool tokens.
     /// (Generally this should not happen absent user error, but may if the
-    /// minimum delegation increases.)
+    /// minimum delegation increases beyond 1 sol.)
     #[error("WithdrawalTooLarge")]
     WithdrawalTooLarge,
     /// Required signature is missing.
@@ -136,7 +136,8 @@ impl PrintProgramError for SinglePoolError {
                 msg!("Error: Not enough pool tokens provided to withdraw stake worth one lamport."),
             SinglePoolError::WithdrawalTooLarge =>
                 msg!("Error: Not enough stake to cover the provided quantity of pool tokens. \
-                     (Generally this should not happen absent user error, but may if the minimum delegation increases.)"),
+                     (Generally this should not happen absent user error, but may if the minimum delegation increases \
+                     beyond 1 sol.)"),
             SinglePoolError::SignatureMissing => msg!("Error: Required signature is missing."),
             SinglePoolError::WrongStakeStake => msg!("Error: Stake account is not in the state expected by the program."),
             SinglePoolError::ArithmeticOverflow => msg!("Error: Unsigned subtraction crossed the zero."),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -26,8 +26,8 @@ use {
 pub enum SinglePoolInstruction {
     ///   Initialize the mint and stake account for a new single-validator
     ///   stake pool. The pool stake account must contain the rent-exempt
-    ///   minimum plus the minimum delegation. No tokens will be minted: to
-    ///   deposit more, use `Deposit` after `InitializeStake`.
+    ///   minimum plus the minimum balance of 1 sol. No tokens will be minted;
+    ///   to deposit more, use `Deposit` after `InitializeStake`.
     ///
     ///   0. `[]` Validator vote account
     ///   1. `[w]` Pool account
@@ -136,7 +136,7 @@ pub fn initialize(
     vote_account_address: &Pubkey,
     payer: &Pubkey,
     rent: &Rent,
-    minimum_delegation: u64,
+    minimum_pool_balance: u64,
 ) -> Vec<Instruction> {
     let pool_address = find_pool_address(program_id, vote_account_address);
     let pool_rent = rent.minimum_balance(std::mem::size_of::<SinglePool>());
@@ -145,7 +145,7 @@ pub fn initialize(
     let stake_space = std::mem::size_of::<stake::state::StakeStateV2>();
     let stake_rent_plus_minimum = rent
         .minimum_balance(stake_space)
-        .saturating_add(minimum_delegation);
+        .saturating_add(minimum_pool_balance);
 
     let mint_address = find_pool_mint_address(program_id, &pool_address);
     let mint_rent = rent.minimum_balance(spl_token::state::Mint::LEN);

--- a/program/tests/accounts.rs
+++ b/program/tests/accounts.rs
@@ -59,7 +59,7 @@ async fn build_instructions(
         .await;
 
         let rent = context.banks_client.get_rent().await.unwrap();
-        let minimum_delegation = get_pool_minimum_delegation(
+        let minimum_pool_balance = get_minimum_pool_balance(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -71,7 +71,7 @@ async fn build_instructions(
             &accounts.vote_account.pubkey(),
             &accounts.alice.pubkey(),
             &rent,
-            minimum_delegation,
+            minimum_pool_balance,
         )
     } else {
         accounts

--- a/program/tests/deposit.rs
+++ b/program/tests/deposit.rs
@@ -403,7 +403,7 @@ async fn fail_activation_mismatch(pool_first: bool) {
     let mut context = program_test(false).start_with_context().await;
     let accounts = SinglePoolAccounts::default();
 
-    let minimum_delegation = get_pool_minimum_delegation(
+    let minimum_pool_balance = get_minimum_pool_balance(
         &mut context.banks_client,
         &context.payer,
         &context.last_blockhash,
@@ -434,7 +434,7 @@ async fn fail_activation_mismatch(pool_first: bool) {
         &accounts.alice_stake,
         &Authorized::auto(&accounts.alice.pubkey()),
         &Lockup::default(),
-        minimum_delegation,
+        minimum_pool_balance,
     )
     .await;
 

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -80,7 +80,7 @@ impl SinglePoolAccounts {
         maybe_bob_amount: Option<u64>,
         activate: bool,
     ) -> u64 {
-        let minimum_delegation = self
+        let minimum_pool_balance = self
             .initialize_for_deposit(context, alice_amount, maybe_bob_amount)
             .await;
 
@@ -150,7 +150,7 @@ impl SinglePoolAccounts {
             .await;
         }
 
-        minimum_delegation
+        minimum_pool_balance
     }
 
     // does everything in initialize plus creates/delegates one or both stake
@@ -162,7 +162,7 @@ impl SinglePoolAccounts {
         alice_amount: u64,
         maybe_bob_amount: Option<u64>,
     ) -> u64 {
-        let minimum_delegation = self.initialize(context).await;
+        let minimum_pool_balance = self.initialize(context).await;
 
         create_independent_stake_account(
             &mut context.banks_client,
@@ -210,7 +210,7 @@ impl SinglePoolAccounts {
             .await;
         };
 
-        minimum_delegation
+        minimum_pool_balance
     }
 
     // creates a vote account and stake pool for it. also sets up two users with sol
@@ -232,7 +232,7 @@ impl SinglePoolAccounts {
         .await;
 
         let rent = context.banks_client.get_rent().await.unwrap();
-        let minimum_delegation = get_pool_minimum_delegation(
+        let minimum_pool_balance = get_minimum_pool_balance(
             &mut context.banks_client,
             &context.payer,
             &context.last_blockhash,
@@ -244,7 +244,7 @@ impl SinglePoolAccounts {
             &self.vote_account.pubkey(),
             &context.payer.pubkey(),
             &rent,
-            minimum_delegation,
+            minimum_pool_balance,
         );
         let transaction = Transaction::new_signed_with_payer(
             &instructions,
@@ -295,7 +295,7 @@ impl SinglePoolAccounts {
         )
         .await;
 
-        minimum_delegation
+        minimum_pool_balance
     }
 }
 impl Default for SinglePoolAccounts {

--- a/program/tests/helpers/stake.rs
+++ b/program/tests/helpers/stake.rs
@@ -39,7 +39,7 @@ pub async fn get_stake_account_rent(banks_client: &mut BanksClient) -> u64 {
     rent.minimum_balance(std::mem::size_of::<stake::state::StakeStateV2>())
 }
 
-pub async fn get_pool_minimum_delegation(
+pub async fn get_minimum_pool_balance(
     banks_client: &mut BanksClient,
     payer: &Keypair,
     recent_blockhash: &Hash,

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -35,7 +35,7 @@ async fn success(enable_minimum_delegation: bool) {
 async fn fail_double_init() {
     let mut context = program_test(false).start_with_context().await;
     let accounts = SinglePoolAccounts::default();
-    let minimum_delegation = accounts.initialize(&mut context).await;
+    let minimum_pool_balance = accounts.initialize(&mut context).await;
     refresh_blockhash(&mut context).await;
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -44,7 +44,7 @@ async fn fail_double_init() {
         &accounts.vote_account.pubkey(),
         &context.payer.pubkey(),
         &rent,
-        minimum_delegation,
+        minimum_pool_balance,
     );
     let transaction = Transaction::new_signed_with_payer(
         &instructions,
@@ -84,7 +84,7 @@ async fn fail_below_pool_minimum(enable_minimum_delegation: bool) {
     .await;
 
     let rent = context.banks_client.get_rent().await.unwrap();
-    let minimum_delegation = get_pool_minimum_delegation(
+    let minimum_pool_balance = get_minimum_pool_balance(
         &mut context.banks_client,
         &context.payer,
         &context.last_blockhash,
@@ -96,7 +96,7 @@ async fn fail_below_pool_minimum(enable_minimum_delegation: bool) {
         &accounts.vote_account.pubkey(),
         &context.payer.pubkey(),
         &rent,
-        minimum_delegation - 1,
+        minimum_pool_balance - 1,
     );
     let transaction = Transaction::new_signed_with_payer(
         &instructions,

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -36,7 +36,7 @@ async fn success(
 
     let amount_deposited = if small_deposit { 1 } else { TEST_STAKE_AMOUNT };
 
-    let minimum_delegation = accounts
+    let minimum_pool_balance = accounts
         .initialize_for_withdraw(
             &mut context,
             amount_deposited,
@@ -127,7 +127,7 @@ async fn success(
     assert_eq!(wallet_lamports_after, wallet_lamports_before);
 
     // pool retains minstake
-    assert_eq!(pool_stake_after, prior_deposits + minimum_delegation);
+    assert_eq!(pool_stake_after, prior_deposits + minimum_pool_balance);
 
     // pool lamports otherwise unchanged. unexpected transfers affect nothing
     assert_eq!(
@@ -155,7 +155,7 @@ async fn success_with_rewards() {
 
     let mut context = program_test(false).start_with_context().await;
     let accounts = SinglePoolAccounts::default();
-    let minimum_delegation = accounts
+    let minimum_pool_balance = accounts
         .initialize_for_withdraw(&mut context, alice_deposit, Some(bob_deposit), true)
         .await;
 
@@ -172,7 +172,7 @@ async fn success_with_rewards() {
     let (_, pool_stake, _) =
         get_stake_account(&mut context.banks_client, &accounts.stake_account).await;
     let pool_stake = pool_stake.unwrap().delegation.stake;
-    let total_rewards = pool_stake - alice_deposit - bob_deposit - minimum_delegation;
+    let total_rewards = pool_stake - alice_deposit - bob_deposit - minimum_pool_balance;
 
     let instructions = instruction::withdraw(
         &id(),
@@ -205,7 +205,7 @@ async fn success_with_rewards() {
 
     let (_, bob_stake, _) =
         get_stake_account(&mut context.banks_client, &accounts.stake_account).await;
-    let bob_rewards = bob_stake.unwrap().delegation.stake - minimum_delegation - bob_deposit;
+    let bob_rewards = bob_stake.unwrap().delegation.stake - minimum_pool_balance - bob_deposit;
 
     // alice tokens are fully burned, bob remains unchanged
     assert_eq!(alice_tokens, 0);


### PR DESCRIPTION
when we wrote this program, we assumed `stake_raise_minimum_delegation_to_1_sol` would be active by time we deployed it. but since it isnt, the use of the term `minimum_delegation` is confusing: we use it to refer to both the stake program-enforced minimum (currently 1 lamp) and the single pool-enforced minimum (floored at 1 sol)

this renames functions and variables that mean the single pool minimum while leaving references to the stake program minimum unchanged. doing this now because it took 15 minutes and i wanted to get it out of the way before adding/refactoring code for the mev rewards pr

note there are no js client changes because we already call it this there

closes #44 