### PR TITLE
ci: run tests regardless of lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,6 @@ jobs:
   build_programs:
     name: Build programs
     runs-on: ubuntu-latest
-    needs: format_and_lint_programs
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -171,7 +170,7 @@ jobs:
   test_programs:
     name: Test Programs
     runs-on: ubuntu-latest
-    needs: format_and_lint_programs
+    needs: build_programs
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
tests should run even if lints fail so ci can be used during a draft pr process