### PR TITLE
CI: Purge runner for cli testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,6 +237,7 @@ jobs:
           cargo-cache-key: cargo-cli
           solana: true
           cli: true
+          purge: true
 
       - name: Restore Program Builds
         uses: actions/cache/restore@v4


### PR DESCRIPTION
#### Problem

The CLI test step can fail due to running out of space on the runner.

#### Summary of changes

Purge the runner in that step