### PR TITLE
CI: Actually use semver script in semver job

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
-    "rust:semver": "cargo semver-checks"
+    "rust:semver": "zx ./scripts/rust/semver.mjs"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
#### Problem

The publish job failed during the semver check, because the semver check wasn't actually using the new script that was added: https://github.com/solana-program/single-pool/actions/runs/13795100962/job/38584712241

#### Summary of changes

Actually use the script