### PR TITLE
CI: add rust publish to pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clients:cli:test": "zx ./scripts/rust/test.mjs clients/cli",
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
+    "rust:publish": "zx ./scripts/rust/publish.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:semver": "zx ./scripts/rust/semver.mjs"
   },


### PR DESCRIPTION
think this is the last puzzle piece

```
Run if [ "true" == "true" ]; then
  if [ "true" == "true" ]; then
    OPTIONS="--dry-run"
  else
    OPTIONS=""
  fi
  
  pnpm rust:publish "program" "major" $OPTIONS
  shell: /usr/bin/bash -e {0}
  env:
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    SOLANA_VERSION: [2](https://github.com/solana-program/single-pool/actions/runs/13804774168/job/38613691800#step:8:2).2.0
    TOOLCHAIN_NIGHTLY: nightly-2024-11-22
    CARGO_REGISTRY_TOKEN: ***
undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "rust:publish" not found

Did you mean "pnpm rust:audit"?
Error: Process completed with exit code 25[4](https://github.com/solana-program/single-pool/actions/runs/13804774168/job/38613691800#step:8:4).
```

cc @joncinque 