### PR TITLE
CI: Install CLI deps before testing publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -45,6 +45,7 @@ jobs:
           clippy: true
           rustfmt: true
           solana: true
+          cli: true
           cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-test-publish
 
@@ -84,6 +85,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
+          cli: true
           cargo-cache-key: cargo-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-publish
 


### PR DESCRIPTION
#### Problem

When testing and publishing packages, they may contain dependencies that require libudev, but we aren't always installing them.

#### Summary of changes

Specify the `cli` flag for all steps during publishing.