### PR TITLE
CI: only run semver for program

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -67,6 +67,7 @@ jobs:
         run: pnpm zx ./scripts/rust/test.mjs "${{ inputs.package_path }}"
 
       - name: Check semver
+        if: ${{ inputs.package_path == 'program' }}
         run: pnpm rust:semver ${{ inputs.package_path }} --release-type ${{ inputs.level }}
 
   publish:


### PR DESCRIPTION
the cargo semver tool does not support binary-only crates

```
Run pnpm rust:semver clients/cli --release-type major

> @ rust:semver /home/runner/work/single-pool/single-pool
> zx ./scripts/rust/semver.mjs "clients/cli" "--release-type" "major"

$ pwd
$ cargo semver-checks --manifest-path /home/runner/work/single-pool/single-pool/clients/cli/Cargo.toml --release-type major
error: no crates with library targets selected, nothing to semver-check
note: only library targets contain an API surface that can be checked for semver
note: skipped the following crates since they have no library target: spl-single-pool-cli
Error: error: no crates with library targets selected, nothing to semver-check
note: only library targets contain an API surface that can be checked for semver
note: skipped the following crates since they have no library target: spl-single-pool-cli
    at Proxy.set (/home/runner/work/single-pool/single-pool/node_modules/.pnpm/zx@8.4.0/node_modules/zx/build/core.cjs:279:[18](https://github.com/solana-program/single-pool/actions/runs/13823673163/job/38674468186#step:9:19))
    exit code: 1
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```