### PR TITLE
use multithreaded runtime in tests

### DIFF
--- a/clients/cli/tests/test.rs
+++ b/clients/cli/tests/test.rs
@@ -262,7 +262,7 @@ async fn create_and_delegate_stake_account(
 
 #[test_case(false; "one_lamp")]
 #[test_case(true; "one_sol")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn replenish_pool(raise_minimum_delegation: bool) {
     let env = setup(raise_minimum_delegation, true).await;
@@ -285,7 +285,7 @@ async fn replenish_pool(raise_minimum_delegation: bool) {
 #[test_case(true, false; "one_sol::normal_stake")]
 #[test_case(false, true; "one_lamp::default_stake")]
 #[test_case(true, true; "one_sol::default_stake")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn deposit(raise_minimum_delegation: bool, use_default: bool) {
     let env = setup(raise_minimum_delegation, true).await;
@@ -333,7 +333,7 @@ async fn deposit(raise_minimum_delegation: bool, use_default: bool) {
 
 #[test_case(false; "one_lamp")]
 #[test_case(true; "one_sol")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn withdraw(raise_minimum_delegation: bool) {
     let env = setup(raise_minimum_delegation, true).await;
@@ -369,7 +369,7 @@ async fn withdraw(raise_minimum_delegation: bool) {
 
 #[test_case(false; "one_lamp")]
 #[test_case(true; "one_sol")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn create_metadata(raise_minimum_delegation: bool) {
     let env = setup(raise_minimum_delegation, false).await;
@@ -403,7 +403,7 @@ async fn create_metadata(raise_minimum_delegation: bool) {
 
 #[test_case(false; "one_lamp")]
 #[test_case(true; "one_sol")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn update_metadata(raise_minimum_delegation: bool) {
     let env = setup(raise_minimum_delegation, true).await;
@@ -442,7 +442,7 @@ async fn update_metadata(raise_minimum_delegation: bool) {
     assert!(status.success());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn display() {
     let env = setup(false, true).await;
@@ -475,7 +475,7 @@ async fn display() {
 
 #[test_case(false; "one_lamp")]
 #[test_case(true; "one_sol")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn create_onramp(raise_minimum_delegation: bool) {
     let env = setup(raise_minimum_delegation, false).await;


### PR DESCRIPTION
#### Problem

These tests create a validator instance inside an async function. This results in the blocking Drop logic being executed within the async task itself.

This design leads to busy waiting when the validator contains async tasks—such as the tpu-client-next service. Since the Tokio runtime is blocked by the synchronous Drop, it can no longer schedule other tasks, including those necessary for shutdown. In particular, if a tpu-client-next instance is running (an async-based service), it will never complete, causing the system to hang.

For example, when attempting to drop the Turbine broadcaster, we end up busy-looping inside BroadcastStage::run, effectively blocking the single-threaded runtime. This issue has been confirmed using tokio-console:

```
11 ▶              32s    32s    0ns  188µs 1     blocking <cargo>/tokio-1.45.1/src/runtime/scheduler/multi_thread/worker|
```

The root cause is that BroadcastStage will only exit when its slot sender is dropped. That sender lives in the PohRecorder, which is part of the mechanism for determining the next leader for the tpu-client. However, since tpu-client-next is an async service, it requires the runtime to remain responsive. The runtime being blocked by Drop prevents this, creating a deadlock.

Similar PR in agave is https://github.com/anza-xyz/agave/pull/6349