### PR TITLE
program: allow onramp in deposit/withdraw

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -83,30 +83,32 @@ pub enum SinglePoolInstruction {
     ///
     ///   0. `[]` Pool account
     ///   1. `[w]` Pool stake account
-    ///   2. `[w]` Pool token mint
-    ///   3. `[]` Pool stake authority
-    ///   4. `[]` Pool mint authority
-    ///   5. `[w]` User stake account to join to the pool
-    ///   6. `[w]` User account to receive pool tokens
-    ///   7. `[w]` User account to receive lamports
-    ///   8. `[]` Clock sysvar
-    ///   9. `[]` Stake history sysvar
-    ///  10. `[]` Token program
-    ///  11. `[]` Stake program
+    ///   2. `[]` Pool on-ramp account (not yet enforced)
+    ///   3. `[w]` Pool token mint
+    ///   4. `[]` Pool stake authority
+    ///   5. `[]` Pool mint authority
+    ///   6. `[w]` User stake account to join to the pool
+    ///   7. `[w]` User account to receive pool tokens
+    ///   8. `[w]` User account to receive lamports
+    ///   9. `[]` Clock sysvar
+    ///  10. `[]` Stake history sysvar
+    ///  11. `[]` Token program
+    ///  12. `[]` Stake program
     DepositStake,
 
     ///   Redeem tokens issued by this pool for stake at the current ratio.
     ///
     ///   0. `[]` Pool account
     ///   1. `[w]` Pool stake account
-    ///   2. `[w]` Pool token mint
-    ///   3. `[]` Pool stake authority
-    ///   4. `[]` Pool mint authority
-    ///   5. `[w]` User stake account to receive stake at
-    ///   6. `[w]` User account to take pool tokens from
-    ///   7. `[]` Clock sysvar
-    ///   8. `[]` Token program
-    ///   9. `[]` Stake program
+    ///   2. `[]` Pool on-ramp account (not yet enforced)
+    ///   3. `[w]` Pool token mint
+    ///   4. `[]` Pool stake authority
+    ///   5. `[]` Pool mint authority
+    ///   6. `[w]` User stake account to receive stake at
+    ///   7. `[w]` User account to take pool tokens from
+    ///   8. `[]` Clock sysvar
+    ///   9. `[]` Token program
+    ///  10. `[]` Stake program
     WithdrawStake {
         /// User authority for the new stake account
         user_stake_authority: Pubkey,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -926,7 +926,16 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let pool_info = next_account_info(account_info_iter)?;
         let pool_stake_info = next_account_info(account_info_iter)?;
-        let pool_mint_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = {
+            let account_info = next_account_info(account_info_iter)?;
+            // we havent validated pool_info yet, so this doesnt validate onramp, but it doesnt matter
+            // for now we just need to know whether to skip an account, we dont actually use it
+            if check_pool_onramp_address(program_id, pool_info.key, account_info.key).is_ok() {
+                next_account_info(account_info_iter)?
+            } else {
+                account_info
+            }
+        };
         let pool_stake_authority_info = next_account_info(account_info_iter)?;
         let pool_mint_authority_info = next_account_info(account_info_iter)?;
         let user_stake_info = next_account_info(account_info_iter)?;
@@ -941,6 +950,7 @@ impl Processor {
         SinglePool::from_account_info(pool_info, program_id)?;
 
         check_pool_stake_address(program_id, pool_info.key, pool_stake_info.key)?;
+        check_pool_mint_address(program_id, pool_info.key, pool_mint_info.key)?;
         let stake_authority_bump_seed = check_pool_stake_authority_address(
             program_id,
             pool_info.key,
@@ -951,7 +961,6 @@ impl Processor {
             pool_info.key,
             pool_mint_authority_info.key,
         )?;
-        check_pool_mint_address(program_id, pool_info.key, pool_mint_info.key)?;
         check_token_program(token_program_info.key)?;
         check_stake_program(stake_program_info.key)?;
 
@@ -1079,7 +1088,16 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let pool_info = next_account_info(account_info_iter)?;
         let pool_stake_info = next_account_info(account_info_iter)?;
-        let pool_mint_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = {
+            let account_info = next_account_info(account_info_iter)?;
+            // we havent validated pool_info yet, so this doesnt validate onramp, but it doesnt matter
+            // for now we just need to know whether to skip an account, we dont actually use it
+            if check_pool_onramp_address(program_id, pool_info.key, account_info.key).is_ok() {
+                next_account_info(account_info_iter)?
+            } else {
+                account_info
+            }
+        };
         let pool_stake_authority_info = next_account_info(account_info_iter)?;
         let pool_mint_authority_info = next_account_info(account_info_iter)?;
         let user_stake_info = next_account_info(account_info_iter)?;
@@ -1091,6 +1109,7 @@ impl Processor {
         SinglePool::from_account_info(pool_info, program_id)?;
 
         check_pool_stake_address(program_id, pool_info.key, pool_stake_info.key)?;
+        check_pool_mint_address(program_id, pool_info.key, pool_mint_info.key)?;
         let stake_authority_bump_seed = check_pool_stake_authority_address(
             program_id,
             pool_info.key,
@@ -1101,7 +1120,6 @@ impl Processor {
             pool_info.key,
             pool_mint_authority_info.key,
         )?;
-        check_pool_mint_address(program_id, pool_info.key, pool_mint_info.key)?;
         check_token_program(token_program_info.key)?;
         check_stake_program(stake_program_info.key)?;
 


### PR DESCRIPTION
part 1/3 of #387. update `DepositStake` and `WithdrawStake` to gracefully handle the onramp account in the accounts list. once this is live, part 2/3 we add it to instruction builders. after communicating with any ecosystem teams needed, part 3/3 we make it mandatory in the program

this will enable us to change the token math to include onramp stake (or possibly all sol, will have to debate), which will further allow us to implement `DepositSol`

i know we typically stick new accounts at the end, but this will eventually be a hard breaking change, so i preferred to keep the "all instructions have all accounts in the same order" property because it pleases me. if we _really_ need to avoid a breaking change, we could put a `onramp_stake` and `last_replenished_epoch` on the pool struct. i would rather avoid this however because, among other reasons, it adds complexity for no benefit

also i moved the mint errors up to match the account ordering