### PR TITLE
program: reserve `DepositSol`

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -169,6 +169,12 @@ pub enum SinglePoolInstruction {
     ///   4. `[]` System program
     ///   5. `[]` Stake program
     InitializePoolOnRamp,
+
+    /// (reserved for future use)
+    DepositSol {
+        /// Amount of sol to deposit
+        lamports: u64,
+    },
 }
 
 /// Creates all necessary instructions to initialize the stake pool.

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1523,6 +1523,10 @@ impl Processor {
                 msg!("Instruction: InitializePoolOnRamp");
                 Self::process_initialize_pool_onramp(program_id, accounts)
             }
+            SinglePoolInstruction::DepositSol { lamports: _ } => {
+                msg!("Instruction: DepositSol (NOT IMPLEMENTED)");
+                Err(ProgramError::InvalidInstructionData)
+            }
         }
     }
 }

--- a/program/tests/accounts.rs
+++ b/program/tests/accounts.rs
@@ -267,6 +267,9 @@ fn make_basic_instruction(
         SinglePoolInstruction::InitializePoolOnRamp => {
             instruction::initialize_pool_onramp(&id(), &accounts.pool)
         }
+        SinglePoolInstruction::DepositSol { .. } => {
+            unimplemented!()
+        }
     }
 }
 
@@ -316,6 +319,7 @@ fn consistent_account_order() {
             },
         ),
         make_basic_instruction(&accounts, SinglePoolInstruction::InitializePoolOnRamp),
+        // TODO SinglePoolInstruction::DepositSol
     ];
 
     for instruction in instructions {


### PR DESCRIPTION
what im planning on doing is finishing all the math stuff and landing this, then releasing v5.0.0 as a just in case checkpoint ready to audit/deploy, but then ideally we dont deploy it, impl `DepositSol`, ~and release as v5.1.0~ (edit: this was a cute idea but changing the error enum blocks a minor version bump, noting in case anyone wonders if the v5.0.0 -> v6.0.0 overlooked this pr comment)

part of #46