### PR TITLE
cli: various improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6419,8 +6419,6 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "bincode",
- "serde_core",
  "solana-address 2.5.0",
  "solana-program-error",
  "solana-program-memory",
@@ -9230,28 +9228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ffb723f5c2aae1b26a69148b3bfe82ffa4918ae7491dcc347436592b42158d"
-dependencies = [
- "bincode",
- "solana-account-info",
- "solana-clock",
- "solana-cpi",
- "solana-instruction-error",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-stake-interface",
- "solana-sysvar",
- "solana-vote-interface 4.0.4",
-]
-
-[[package]]
 name = "solana-storage-bigtable"
 version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10094,7 +10070,6 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-keypair",
- "solana-metrics",
  "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
@@ -10327,46 +10302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-elgamal-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd22edf24c47c4610b160f49c12fe33b19aec2a0968e3c9cd412fa2a94ae2bb"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-elgamal-registry-interface",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
-name = "spl-elgamal-registry-interface"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065f54100d118d24036283e03120b2f60cb5b7d597d3db649e13690e22d41398"
-dependencies = [
- "bytemuck",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-zk-sdk",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
 name = "spl-generic-token"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10403,54 +10338,6 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-zero-copy",
  "solana-zk-sdk",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4f6cf26cb6768110bf024bc7224326c720d711f7ad25d16f40f6cee40edb2d"
-dependencies = [
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec8965aa4dc6c74701cbb48b9cad5af35b9a394514934949edbb357b78f840d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.9",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "spl-record"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda0eb42ca6387770d7f0e764ecd8fa863f4529e9ff35fbf146576b5f4372587"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-security-txt",
  "thiserror 2.0.18",
 ]
 
@@ -10527,6 +10414,7 @@ dependencies = [
  "solana-keypair",
  "solana-logger",
  "solana-native-token",
+ "solana-program-pack",
  "solana-pubkey 4.2.0",
  "solana-remote-wallet",
  "solana-rent 3.1.0",
@@ -10534,110 +10422,18 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-stake-program",
  "solana-system-interface 3.0.0",
  "solana-sysvar",
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-status",
- "solana-vote-program",
+ "solana-vote-interface 5.0.0",
  "spl-associated-token-account-interface",
  "spl-single-pool",
- "spl-token",
- "spl-token-client",
+ "spl-token-interface",
  "tempfile",
  "test-case",
  "tokio",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878b0183d51fcd8a53e1604f4c13321894cf53227e6773c529b0d03d499a8dfd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-sysvar",
- "spl-token-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552427d9117528d037daa0e70416d51322c8a33241317210f230304d852be61e"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-clock",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-elgamal-registry-interface",
- "spl-memo-interface",
- "spl-pod",
- "spl-token-2022-interface",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10666,61 +10462,6 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-type-length-value",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-client"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f87005f510593cc674a4f9f257bedbecfbb35f5aae1b66a65ef9b7dbccdeb5"
-dependencies = [
- "async-trait",
- "bincode",
- "bytemuck",
- "futures 0.3.32",
- "futures-util",
- "solana-account",
- "solana-cli-output",
- "solana-compute-budget-interface",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-message",
- "solana-packet",
- "solana-program-error",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-signature",
- "solana-signer",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "spl-associated-token-account-interface",
- "spl-elgamal-registry",
- "spl-memo-interface",
- "spl-record",
- "spl-token-2022",
- "spl-token-2022-interface",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbeb07f737d868f145512a4bcf9f59da275b7a3483df0add3f71eb812b689fb"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
 ]
 
 [[package]]
@@ -10807,32 +10548,6 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "spl-discriminator",
  "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-interface 2.0.0",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
  "spl-type-length-value",
  "thiserror 2.0.18",
 ]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -31,6 +31,7 @@ solana-instruction = "3.0"
 solana-keypair = "3.0"
 solana-logger = "3.0"
 solana-native-token = "3.0"
+solana-program-pack = "3.0"
 solana-pubkey = "4.2"
 solana-remote-wallet = "3.1.3"
 solana-rent = "3.0"
@@ -40,13 +41,11 @@ solana-signer = "3.0"
 solana-system-interface = "3.0"
 solana-sysvar = "3.1"
 solana-stake-interface = "2.0.1"
-solana-stake-program = "4.0"
 solana-transaction = "3.0"
 solana-transaction-status = "3.1.3"
-solana-vote-program = "3.1"
+solana-vote-interface = { version = "5.0.0", features = ["bincode"] }
 spl-associated-token-account-interface = "2.0.0"
-spl-token = { version = "9.0", features = ["no-entrypoint"] }
-spl-token-client = { version = "0.18.0" }
+spl-token-interface = "2.0.0"
 spl-single-pool = { version = "5.0.0", path = "../../program", features = [
   "no-entrypoint",
 ] }

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -7,7 +7,6 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_signer::Signer,
-    spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
     std::{process::exit, rc::Rc, sync::Arc},
 };
 
@@ -24,7 +23,6 @@ pub fn println_display(config: &Config, message: String) {
 
 pub struct Config {
     pub rpc_client: Arc<RpcClient>,
-    pub program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>>,
     pub default_signer: Option<Arc<dyn Signer>>,
     pub fee_payer: Option<Arc<dyn Signer>>,
     pub output_format: OutputFormat,
@@ -54,12 +52,6 @@ impl Config {
             CommitmentConfig::confirmed(),
         ));
 
-        // and program client
-        let program_client = Arc::new(ProgramRpcClient::new(
-            rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
-        ));
-
         // resolve default signer
         let default_keypair = cli_config.keypair_path;
         let default_signer =
@@ -86,7 +78,6 @@ impl Config {
 
         Self {
             rpc_client,
-            program_client,
             default_signer,
             fee_payer,
             output_format,

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,10 +1,12 @@
 use {
     crate::cli::*,
     clap::ArgMatches,
+    solana_account::Account,
     solana_clap_v3_utils::keypair::{signer_from_path, signer_from_source},
     solana_cli_output::OutputFormat,
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_commitment_config::CommitmentConfig,
+    solana_pubkey::Pubkey,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_signer::Signer,
     std::{process::exit, rc::Rc, sync::Arc},
@@ -111,5 +113,14 @@ impl Config {
 
     pub fn verbose(&self) -> bool {
         self.output_format == OutputFormat::DisplayVerbose
+    }
+
+    pub async fn get_initialized_account(&self, pubkey: Pubkey) -> Result<Option<Account>, Error> {
+        Ok(self
+            .rpc_client
+            .get_account_with_commitment(&pubkey, self.rpc_client.commitment())
+            .await?
+            .value
+            .filter(|account| !account.data.is_empty()))
     }
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -15,15 +15,17 @@ use {
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_signature::Signature,
     solana_signer::Signer,
-    solana_stake_interface as stake,
+    solana_stake_interface::{self as stake, state::StakeStateV2},
     solana_transaction::Transaction,
-    solana_vote_program::{self as vote_program, vote_state::VoteStateV4},
-    spl_associated_token_account_interface::instruction::create_associated_token_account,
+    solana_vote_interface::{program as vote_program, state::VoteStateV4},
+    spl_associated_token_account_interface::{
+        address::get_associated_token_address, instruction::create_associated_token_account,
+    },
     spl_single_pool::{
         self, find_pool_address, find_pool_mint_address, find_pool_onramp_address,
         find_pool_stake_address, instruction::SinglePoolInstruction, state::SinglePool,
     },
-    spl_token_client::token::Token,
+    spl_token_interface as spl_token,
     std::{rc::Rc, sync::Arc},
 };
 
@@ -129,12 +131,14 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         .into());
     };
 
+    let minimum_pool_balance = quarantine::get_minimum_pool_balance(config).await?;
+
     let mut instructions = spl_single_pool::instruction::initialize(
         &spl_single_pool::id(),
         &vote_account_address,
         &payer.pubkey(),
         &quarantine::get_rent(config).await?,
-        quarantine::get_minimum_pool_balance(config).await?,
+        minimum_pool_balance,
     );
 
     // get rid of the CreateMetadata instruction if desired, eg if mpl breaks compat
@@ -151,7 +155,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         &instructions,
         Some(&payer.pubkey()),
         &vec![payer],
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -162,9 +166,12 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
         StakePoolOutput {
             pool_address,
             vote_account_address,
-            available_stake: 0,
-            excess_lamports: 0,
-            token_supply: 0,
+            net_asset_value: minimum_pool_balance,
+            undelegated_lamports: 0,
+            token_supply: quarantine::PHANTOM_TOKENS,
+            main_stake_dedelegated: false,
+            onramp_exists: true,
+            minimum_delegation: 0, // only used to warn to replenish
             signature,
         },
     ))
@@ -191,7 +198,7 @@ async fn command_replenish_pool(config: &Config, command_config: ReplenishCli) -
         &[instruction],
         Some(&payer.pubkey()),
         &vec![payer],
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -303,23 +310,18 @@ async fn command_deposit(
         return Err("Activation status mismatch; try again next epoch".into());
     }
 
-    let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
-    let token = Token::new(
-        config.program_client.clone(),
-        &spl_token::id(),
-        &pool_mint_address,
-        None,
-        payer.clone(),
-    );
-
     let mut instructions = vec![];
 
     // use token account provided, or get/create the associated account for the client keypair
+    let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
     let token_account_address = if let Some(account) = command_config.token_account_address {
         account
     } else {
-        let address = token.get_associated_token_address(&owner.pubkey());
-        if get_initialized_account(config, address).await?.is_none() {
+        let ata_address = get_associated_token_address(&owner.pubkey(), &pool_mint_address);
+        if quarantine::get_token_info(config, &ata_address, &pool_mint_address)
+            .await?
+            .is_none()
+        {
             instructions.push(create_associated_token_account(
                 &payer.pubkey(),
                 &owner.pubkey(),
@@ -327,13 +329,14 @@ async fn command_deposit(
                 &spl_token::id(),
             ));
         }
-        address
+        ata_address
     };
 
-    let previous_token_amount = match token.get_account_info(&token_account_address).await {
-        Ok(account) => account.base.amount,
-        Err(_) => 0,
-    };
+    let previous_token_amount =
+        quarantine::get_token_info(config, &token_account_address, &pool_mint_address)
+            .await?
+            .map(|token_account| token_account.amount)
+            .unwrap_or(0);
 
     instructions.extend(spl_single_pool::instruction::deposit(
         &spl_single_pool::id(),
@@ -355,7 +358,7 @@ async fn command_deposit(
         &instructions,
         Some(&payer.pubkey()),
         &signers,
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -364,11 +367,10 @@ async fn command_deposit(
         None
     } else {
         Some(
-            token
-                .get_account_info(&token_account_address)
+            quarantine::get_token_info(config, &token_account_address, &pool_mint_address)
                 .await?
-                .base
-                .amount
+                .map(|token_account| token_account.amount)
+                .unwrap_or(0)
                 - previous_token_amount,
         )
     };
@@ -417,24 +419,19 @@ async fn command_withdraw(
 
     pool_is_initialized(config, pool_address).await?;
 
-    // now all the mint and token info
     let pool_mint_address = find_pool_mint_address(&spl_single_pool::id(), &pool_address);
-    let token = Token::new(
-        config.program_client.clone(),
-        &spl_token::id(),
-        &pool_mint_address,
-        None,
-        payer.clone(),
-    );
-
     let token_account_address = command_config
         .token_account_address
-        .unwrap_or_else(|| token.get_associated_token_address(&owner.pubkey()));
+        .unwrap_or_else(|| get_associated_token_address(&owner.pubkey(), &pool_mint_address));
 
-    let token_account = token.get_account_info(&token_account_address).await?;
+    let Some(token_account) =
+        quarantine::get_token_info(config, &token_account_address, &pool_mint_address).await?
+    else {
+        return Err(format!("Token account {} does not exist", token_account_address).into());
+    };
 
     let token_amount = match command_config.token_amount.sol_to_lamport() {
-        Amount::All => token_account.base.amount,
+        Amount::All => token_account.amount,
         Amount::Raw(amount) => amount,
         Amount::Decimal(_) => unreachable!(),
     };
@@ -451,21 +448,20 @@ async fn command_withdraw(
         return Err("Cannot withdraw zero tokens".into());
     }
 
-    if token_amount > token_account.base.amount {
+    if token_amount > token_account.amount {
         return Err(format!(
             "Withdraw amount {} exceeds tokens in account ({})",
-            token_amount, token_account.base.amount
+            token_amount, token_account.amount,
         )
         .into());
     }
 
-    // note a delegate authority is not allowed here because we must authorize the
-    // pool authority
-    if token_account.base.owner != token_authority.pubkey() {
+    // note a delegate authority is not allowed here because we must authorize the pool authority
+    if token_account.owner != token_authority.pubkey() {
         return Err(format!(
             "Invalid token authority: got {}, actual {}",
-            token_account.base.owner,
-            token_authority.pubkey()
+            token_account.owner,
+            token_authority.pubkey(),
         )
         .into());
     }
@@ -510,7 +506,7 @@ async fn command_withdraw(
         &instructions,
         Some(&payer.pubkey()),
         &signers,
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -573,7 +569,7 @@ async fn command_create_metadata(
         &[instruction],
         Some(&payer.pubkey()),
         &vec![payer],
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -618,11 +614,7 @@ async fn command_update_metadata(
     // we always need the vote account
     let vote_account_address = get_vote_address_from_pool(config, pool_address).await?;
 
-    if let Some(vote_account_data) = config
-        .program_client
-        .get_account(vote_account_address)
-        .await?
-    {
+    if let Ok(vote_account_data) = config.rpc_client.get_account(&vote_account_address).await {
         let vote_account =
             VoteStateV4::deserialize(&vote_account_data.data, &vote_account_address)?;
 
@@ -635,8 +627,7 @@ async fn command_update_metadata(
             .into());
         }
     } else {
-        // we know the pool exists so the vote account must exist
-        unreachable!();
+        return Err(format!("Vote account {} does not exist", vote_account_address).into());
     }
 
     let instruction = spl_single_pool::instruction::update_token_metadata(
@@ -659,7 +650,7 @@ async fn command_update_metadata(
         &[instruction],
         Some(&payer.pubkey()),
         &signers,
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -673,7 +664,13 @@ async fn command_update_metadata(
 
 // display stake pool(s)
 async fn command_display(config: &Config, command_config: DisplayCli) -> CommandResult {
-    let minimum_pool_balance = quarantine::get_minimum_pool_balance(config).await?;
+    let stake_rent_exempt_reserve = config
+        .rpc_client
+        .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
+        .await?;
+    let current_epoch = config.rpc_client.get_epoch_info().await?.epoch;
+    let minimum_delegation = config.rpc_client.get_stake_minimum_delegation().await?;
+
     let pool_and_vote_addresses = if command_config.all {
         // the filter isn't necessary now but makes the cli forward-compatible
         #[allow(deprecated)]
@@ -719,36 +716,65 @@ async fn command_display(config: &Config, command_config: DisplayCli) -> Command
         );
     }
 
-    let stake_addresses = pool_and_vote_addresses
-        .iter()
-        .map(|(pool_address, _)| find_pool_stake_address(&spl_single_pool::id(), pool_address))
-        .collect::<Vec<_>>();
+    let stake_summaries = {
+        let stake_addresses = pool_and_vote_addresses
+            .iter()
+            .map(|(pool_address, _)| find_pool_stake_address(&spl_single_pool::id(), pool_address))
+            .collect::<Vec<_>>();
 
-    let available_balances =
-        quarantine::get_available_balances(config, &stake_addresses, minimum_pool_balance).await?;
+        quarantine::get_stake_summaries(
+            config,
+            &stake_addresses,
+            stake_rent_exempt_reserve,
+            current_epoch,
+        )
+        .await?
+    };
 
-    let mint_addresses = pool_and_vote_addresses
-        .iter()
-        .map(|(pool_address, _)| find_pool_mint_address(&spl_single_pool::id(), pool_address))
-        .collect::<Vec<_>>();
+    let onramp_summaries = {
+        let onramp_addresses = pool_and_vote_addresses
+            .iter()
+            .map(|(pool_address, _)| find_pool_onramp_address(&spl_single_pool::id(), pool_address))
+            .collect::<Vec<_>>();
 
-    let token_supplies = quarantine::get_token_supplies(config, &mint_addresses).await?;
+        quarantine::get_stake_summaries(
+            config,
+            &onramp_addresses,
+            stake_rent_exempt_reserve,
+            current_epoch,
+        )
+        .await?
+    };
+
+    let token_supplies = {
+        let mint_addresses = pool_and_vote_addresses
+            .iter()
+            .map(|(pool_address, _)| find_pool_mint_address(&spl_single_pool::id(), pool_address))
+            .collect::<Vec<_>>();
+
+        quarantine::get_token_supplies(config, &mint_addresses).await?
+    };
 
     let mut displays = vec![];
-    for (
-        ((pool_address, vote_account_address), (available_stake, excess_lamports)),
-        token_supply,
-    ) in pool_and_vote_addresses
-        .into_iter()
-        .zip(available_balances)
-        .zip(token_supplies)
+    for ((((pool_address, vote_account_address), stake_summary), onramp_summary), token_supply) in
+        pool_and_vote_addresses
+            .into_iter()
+            .zip(stake_summaries)
+            .zip(onramp_summaries)
+            .zip(token_supplies)
     {
+        let net_asset_value = stake_summary.nav(onramp_summary);
+        let undelegated_lamports = stake_summary.excess_lamports(onramp_summary);
+
         displays.push(StakePoolOutput {
             pool_address,
             vote_account_address,
-            available_stake,
-            excess_lamports,
+            net_asset_value,
+            undelegated_lamports,
             token_supply,
+            main_stake_dedelegated: stake_summary.dedelegated,
+            onramp_exists: onramp_summary.exists,
+            minimum_delegation,
             signature: None,
         });
     }
@@ -810,7 +836,7 @@ async fn command_create_onramp(config: &Config, command_config: CreateOnRampCli)
         &instructions,
         Some(&payer.pubkey()),
         &vec![payer],
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
 
     let signature = process_transaction(config, transaction).await?;
@@ -827,9 +853,10 @@ async fn get_initialized_account(
     pubkey: Pubkey,
 ) -> Result<Option<Account>, Error> {
     Ok(config
-        .program_client
-        .get_account(pubkey)
+        .rpc_client
+        .get_account_with_commitment(&pubkey, config.rpc_client.commitment())
         .await?
+        .value
         .filter(|account| !account.data.is_empty()))
 }
 
@@ -869,7 +896,15 @@ async fn process_transaction(
     if config.dry_run {
         let simulation_data = config.rpc_client.simulate_transaction(&transaction).await?;
 
-        if config.verbose() {
+        if simulation_data.value.err.is_none() && !config.verbose() {
+            println_display(config, "Simulation succeeded".to_string());
+        } else {
+            let status_str = if simulation_data.value.err.is_some() {
+                "FAILED"
+            } else {
+                "succeeded"
+            };
+
             if let Some(logs) = simulation_data.value.logs {
                 for log in logs {
                     println!("    {}", log);
@@ -877,11 +912,10 @@ async fn process_transaction(
             }
 
             println!(
-                "\nSimulation succeeded, consumed {} compute units",
-                simulation_data.value.units_consumed.unwrap()
+                "\nSimulation {}, consumed {} compute units",
+                status_str,
+                simulation_data.value.units_consumed.unwrap(),
             );
-        } else {
-            println_display(config, "Simulation succeeded".to_string());
         }
 
         Ok(None)

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -3,7 +3,6 @@
 
 use {
     clap::{ArgMatches, CommandFactory, Parser},
-    solana_account::Account,
     solana_borsh::v1::try_from_slice_unchecked,
     solana_clap_v3_utils::{input_parsers::Amount, keypair::signer_from_source},
     solana_client::{
@@ -111,7 +110,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
     );
 
     // check if the vote account is valid
-    match get_initialized_account(config, vote_account_address).await? {
+    match config.get_initialized_account(vote_account_address).await? {
         Some(vote_account)
             if vote_account.owner == vote_program::id()
                 && VoteStateV4::deserialize(&vote_account.data, &vote_account_address).is_ok() => {}
@@ -123,7 +122,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
     // the pool must not already be initialized
     // we do not use `pool_is_initialized()` because that function is restrictive
     // so its negation would be permissive
-    let None = get_initialized_account(config, pool_address).await? else {
+    let None = config.get_initialized_account(pool_address).await? else {
         return Err(format!(
             "Pool {} for vote account {} already exists",
             pool_address, vote_account_address
@@ -246,7 +245,7 @@ async fn command_deposit(
 
     // now we validate the stake account and definitively resolve the pool address
     let (pool_address, user_stake_active) = if let Some((meta, stake)) =
-        quarantine::get_stake_info(config, &stake_account_address).await?
+        quarantine::get_stake_info(config, stake_account_address).await?
     {
         let derived_pool_address =
             find_pool_address(&spl_single_pool::id(), &stake.delegation.voter_pubkey);
@@ -298,7 +297,7 @@ async fn command_deposit(
     pool_is_initialized(config, pool_address).await?;
 
     let pool_stake_address = find_pool_stake_address(&spl_single_pool::id(), &pool_address);
-    let pool_stake_active = quarantine::get_stake_info(config, &pool_stake_address)
+    let pool_stake_active = quarantine::get_stake_info(config, pool_stake_address)
         .await?
         .unwrap()
         .1
@@ -318,7 +317,7 @@ async fn command_deposit(
         account
     } else {
         let ata_address = get_associated_token_address(&owner.pubkey(), &pool_mint_address);
-        if quarantine::get_token_info(config, &ata_address, &pool_mint_address)
+        if quarantine::get_token_info(config, ata_address, pool_mint_address)
             .await?
             .is_none()
         {
@@ -333,7 +332,7 @@ async fn command_deposit(
     };
 
     let previous_token_amount =
-        quarantine::get_token_info(config, &token_account_address, &pool_mint_address)
+        quarantine::get_token_info(config, token_account_address, pool_mint_address)
             .await?
             .map(|token_account| token_account.amount)
             .unwrap_or(0);
@@ -367,7 +366,7 @@ async fn command_deposit(
         None
     } else {
         Some(
-            quarantine::get_token_info(config, &token_account_address, &pool_mint_address)
+            quarantine::get_token_info(config, token_account_address, pool_mint_address)
                 .await?
                 .map(|token_account| token_account.amount)
                 .unwrap_or(0)
@@ -425,7 +424,7 @@ async fn command_withdraw(
         .unwrap_or_else(|| get_associated_token_address(&owner.pubkey(), &pool_mint_address));
 
     let Some(token_account) =
-        quarantine::get_token_info(config, &token_account_address, &pool_mint_address).await?
+        quarantine::get_token_info(config, token_account_address, pool_mint_address).await?
     else {
         return Err(format!("Token account {} does not exist", token_account_address).into());
     };
@@ -514,7 +513,7 @@ async fn command_withdraw(
     let stake_amount = if config.dry_run {
         None
     } else if let Some((_, stake)) =
-        quarantine::get_stake_info(config, &stake_account_address).await?
+        quarantine::get_stake_info(config, stake_account_address).await?
     {
         Some(stake.delegation.stake)
     } else {
@@ -614,7 +613,7 @@ async fn command_update_metadata(
     // we always need the vote account
     let vote_account_address = get_vote_address_from_pool(config, pool_address).await?;
 
-    if let Ok(vote_account_data) = config.rpc_client.get_account(&vote_account_address).await {
+    if let Some(vote_account_data) = config.get_initialized_account(vote_account_address).await? {
         let vote_account =
             VoteStateV4::deserialize(&vote_account_data.data, &vote_account_address)?;
 
@@ -814,7 +813,8 @@ async fn command_create_onramp(config: &Config, command_config: CreateOnRampCli)
 
     pool_is_initialized(config, pool_address).await?;
 
-    if get_initialized_account(config, onramp_address)
+    if config
+        .get_initialized_account(onramp_address)
         .await?
         .is_some()
     {
@@ -848,23 +848,11 @@ async fn command_create_onramp(config: &Config, command_config: CreateOnRampCli)
     ))
 }
 
-async fn get_initialized_account(
-    config: &Config,
-    pubkey: Pubkey,
-) -> Result<Option<Account>, Error> {
-    Ok(config
-        .rpc_client
-        .get_account_with_commitment(&pubkey, config.rpc_client.commitment())
-        .await?
-        .value
-        .filter(|account| !account.data.is_empty()))
-}
-
 async fn get_vote_address_from_pool(
     config: &Config,
     pool_address: Pubkey,
 ) -> Result<Pubkey, Error> {
-    let Some(pool_account) = get_initialized_account(config, pool_address).await? else {
+    let Some(pool_account) = config.get_initialized_account(pool_address).await? else {
         return Err(format!("Pool {} has not been initialized", pool_address).into());
     };
 

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -3,7 +3,10 @@ use {
     console::style,
     serde::{Deserialize, Serialize},
     serde_with::{serde_as, DisplayFromStr},
-    solana_cli_output::{display::writeln_name_value, QuietDisplay, VerboseDisplay},
+    solana_cli_output::{
+        display::{build_balance_message, writeln_name_value},
+        QuietDisplay, VerboseDisplay,
+    },
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     spl_single_pool::{
@@ -93,9 +96,14 @@ pub struct StakePoolOutput {
     pub pool_address: Pubkey,
     #[serde_as(as = "DisplayFromStr")]
     pub vote_account_address: Pubkey,
-    pub available_stake: u64,
-    pub excess_lamports: u64,
+    pub net_asset_value: u64,
+    pub undelegated_lamports: u64,
     pub token_supply: u64,
+    pub main_stake_dedelegated: bool,
+    pub onramp_exists: bool,
+    #[serde(skip)]
+    pub minimum_delegation: u64,
+
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub signature: Option<Signature>,
 }
@@ -146,9 +154,19 @@ impl VerboseDisplay for StakePoolOutput {
                 .to_string(),
         )?;
 
-        writeln_name_value(w, "  Available stake:", &self.available_stake.to_string())?;
-        writeln_name_value(w, "  Excess lamports:", &self.excess_lamports.to_string())?;
-        writeln_name_value(w, "  Token supply:", &self.token_supply.to_string())?;
+        writeln_name_value(w, "  Net asset value:", &self.net_asset_value.to_string())?;
+        writeln_name_value(
+            w,
+            "  Undelegated lamports:",
+            &self.undelegated_lamports.to_string(),
+        )?;
+        writeln_name_value(
+            w,
+            "  Notional token supply:",
+            &self.token_supply.to_string(),
+        )?;
+
+        self.print_shared_warnings(w)?;
 
         if let Some(signature) = self.signature {
             writeln!(w)?;
@@ -169,12 +187,51 @@ impl Display for StakePoolOutput {
             "  Vote account address:",
             &self.vote_account_address.to_string(),
         )?;
-        writeln_name_value(f, "  Available stake:", &self.available_stake.to_string())?;
-        writeln_name_value(f, "  Token supply:", &self.token_supply.to_string())?;
+        writeln_name_value(f, "  Net asset value:", &self.net_asset_value.to_string())?;
+        writeln_name_value(
+            f,
+            "  Notional token supply:",
+            &self.token_supply.to_string(),
+        )?;
+
+        self.print_shared_warnings(f)?;
 
         if let Some(signature) = self.signature {
             writeln!(f)?;
             writeln_name_value(f, "Signature:", &signature.to_string())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl StakePoolOutput {
+    fn print_shared_warnings(&self, w: &mut dyn Write) -> Result {
+        // these are not mutually exclusive, we just use `else if` for ux reasons.
+        // namely, dont tell the user to create an onramp if the pool is unusable,
+        // and dont tell the user to replenish if theres no onramp yet.
+        // it is a bit weird tho because they cant fix an undelegated main account without an onramp.
+        // but we *dont* want to tell an unsavvy user to blindly replenish in this case,
+        // since *we* dont know if the vote account is back in good standing without a bunch of out-of-scope nonsense
+        if self.main_stake_dedelegated {
+            writeln!(
+                w,
+                "{} This validator's vote account may be delinquent or closed!",
+                style("/!\\ POOL STAKE IS UNDELEGATED /!\\").bold(),
+            )?;
+        } else if !self.onramp_exists {
+            writeln!(
+                w,
+                "{} Onramp does not exist; use `spl-single-pool manage create-on-ramp` to create it",
+                style("/!\\").bold(),
+            )?;
+        } else if self.undelegated_lamports > self.minimum_delegation {
+            writeln!(
+                w,
+                "{} This pool has {} not earning rewards; use `spl-single-pool manage replenish-pool` to delegate it",
+                style("/!\\").bold(),
+                build_balance_message(self.undelegated_lamports, false, true),
+            )?;
         }
 
         Ok(())
@@ -187,14 +244,17 @@ pub struct StakePoolListOutput(pub Vec<StakePoolOutput>);
 impl QuietDisplay for StakePoolListOutput {}
 impl VerboseDisplay for StakePoolListOutput {
     fn write_str(&self, w: &mut dyn Write) -> Result {
-        let mut stake = 0;
+        let mut nav = 0;
         for svsp in &self.0 {
             VerboseDisplay::write_str(svsp, w)?;
-            stake += svsp.available_stake;
+            nav += svsp.net_asset_value;
         }
 
-        writeln!(w)?;
-        writeln_name_value(w, "Total stake:", &stake.to_string())?;
+        writeln_name_value(
+            w,
+            "\nTotal value:",
+            &build_balance_message(nav, false, true),
+        )?;
 
         Ok(())
     }
@@ -202,14 +262,17 @@ impl VerboseDisplay for StakePoolListOutput {
 
 impl Display for StakePoolListOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let mut stake = 0;
+        let mut nav = 0;
         for svsp in &self.0 {
             svsp.fmt(f)?;
-            stake += svsp.available_stake;
+            nav += svsp.net_asset_value;
         }
 
-        writeln!(f)?;
-        writeln_name_value(f, "Total stake:", &stake.to_string())?;
+        writeln_name_value(
+            f,
+            "\nTotal value:",
+            &build_balance_message(nav, false, true),
+        )?;
 
         Ok(())
     }

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -225,7 +225,7 @@ impl StakePoolOutput {
                 "{} Onramp does not exist; use `spl-single-pool manage create-on-ramp` to create it",
                 style("/!\\").bold(),
             )?;
-        } else if self.undelegated_lamports > self.minimum_delegation {
+        } else if self.undelegated_lamports >= self.minimum_delegation {
             writeln!(
                 w,
                 "{} This pool has {} not earning rewards; use `spl-single-pool manage replenish-pool` to delegate it",

--- a/clients/cli/src/quarantine.rs
+++ b/clients/cli/src/quarantine.rs
@@ -21,7 +21,10 @@ use {
 pub const PHANTOM_TOKENS: u64 = LAMPORTS_PER_SOL;
 
 pub async fn get_rent(config: &Config) -> Result<Rent, Error> {
-    let rent_data = config.rpc_client.get_account(&sysvar::rent::id()).await?;
+    let rent_data = config
+        .get_initialized_account(sysvar::rent::id())
+        .await?
+        .unwrap();
     let rent = bincode::deserialize::<Rent>(&rent_data.data)?;
 
     Ok(rent)
@@ -36,10 +39,13 @@ pub async fn get_minimum_pool_balance(config: &Config) -> Result<u64, Error> {
 
 pub async fn get_stake_info(
     config: &Config,
-    stake_account_address: &Pubkey,
+    stake_account_address: Pubkey,
 ) -> Result<Option<(Meta, Stake)>, Error> {
-    if let Ok(stake_account) = config.rpc_client.get_account(stake_account_address).await {
-        match bincode::deserialize::<StakeStateV2>(&stake_account.data)? {
+    if let Some(account) = config
+        .get_initialized_account(stake_account_address)
+        .await?
+    {
+        match bincode::deserialize::<StakeStateV2>(&account.data)? {
             StakeStateV2::Stake(meta, stake, _) => Ok(Some((meta, stake))),
             StakeStateV2::Initialized(_) => {
                 Err(format!("Stake account {} is undelegated", stake_account_address).into())
@@ -56,13 +62,16 @@ pub async fn get_stake_info(
 
 pub async fn get_token_info(
     config: &Config,
-    token_account_address: &Pubkey,
-    mint_address: &Pubkey,
+    token_account_address: Pubkey,
+    mint_address: Pubkey,
 ) -> Result<Option<TokenAccount>, Error> {
-    if let Ok(account) = config.rpc_client.get_account(token_account_address).await {
+    if let Some(account) = config
+        .get_initialized_account(token_account_address)
+        .await?
+    {
         match TokenAccount::unpack(&account.data) {
             Ok(token_account)
-                if account.owner == spl_token::id() && &token_account.mint == mint_address =>
+                if account.owner == spl_token::id() && token_account.mint == mint_address =>
             {
                 Ok(Some(token_account))
             }

--- a/clients/cli/src/quarantine.rs
+++ b/clients/cli/src/quarantine.rs
@@ -115,9 +115,8 @@ pub async fn get_stake_summaries(
             // if this assert ever triggers, multistake or another account change has landed
             // this function should be updated to use real stake account sizes
             // we may be fetching hundreds of accounts here so memoize the rents
-            assert_eq!(
-                account.data.len(),
-                StakeStateV2::size_of(),
+            assert!(
+                !account.data.is_empty() && account.data.len() != StakeStateV2::size_of(),
                 "StakeStateV2 is no longer canonical, or StakeStateV2::size_of() is no longer 200."
             );
 

--- a/clients/cli/src/quarantine.rs
+++ b/clients/cli/src/quarantine.rs
@@ -1,10 +1,9 @@
-// XXX this file will be deleted and replaced with a stake program client once i
-// write one
-
 use {
     crate::config::*,
+    solana_clock::Epoch,
     solana_instruction::Instruction,
     solana_native_token::LAMPORTS_PER_SOL,
+    solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_stake_interface::{
@@ -13,15 +12,16 @@ use {
     },
     solana_system_interface::instruction as system_instruction,
     solana_sysvar as sysvar,
-    spl_token::{solana_program::program_pack::Pack, state::Mint},
+    spl_token_interface::{
+        self as spl_token,
+        state::{Account as TokenAccount, Mint},
+    },
 };
 
+pub const PHANTOM_TOKENS: u64 = LAMPORTS_PER_SOL;
+
 pub async fn get_rent(config: &Config) -> Result<Rent, Error> {
-    let rent_data = config
-        .program_client
-        .get_account(sysvar::rent::id())
-        .await?
-        .unwrap();
+    let rent_data = config.rpc_client.get_account(&sysvar::rent::id()).await?;
     let rent = bincode::deserialize::<Rent>(&rent_data.data)?;
 
     Ok(rent)
@@ -38,11 +38,7 @@ pub async fn get_stake_info(
     config: &Config,
     stake_account_address: &Pubkey,
 ) -> Result<Option<(Meta, Stake)>, Error> {
-    if let Some(stake_account) = config
-        .program_client
-        .get_account(*stake_account_address)
-        .await?
-    {
+    if let Ok(stake_account) = config.rpc_client.get_account(stake_account_address).await {
         match bincode::deserialize::<StakeStateV2>(&stake_account.data)? {
             StakeStateV2::Stake(meta, stake, _) => Ok(Some((meta, stake))),
             StakeStateV2::Initialized(_) => {
@@ -58,24 +54,64 @@ pub async fn get_stake_info(
     }
 }
 
-pub async fn get_available_balances(
+pub async fn get_token_info(
+    config: &Config,
+    token_account_address: &Pubkey,
+    mint_address: &Pubkey,
+) -> Result<Option<TokenAccount>, Error> {
+    if let Ok(account) = config.rpc_client.get_account(token_account_address).await {
+        match TokenAccount::unpack(&account.data) {
+            Ok(token_account)
+                if account.owner == spl_token::id() && &token_account.mint == mint_address =>
+            {
+                Ok(Some(token_account))
+            }
+            _ => Err(format!("Invalid token account {}", token_account_address).into()),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct StakeSummary {
+    // `stake.delegation.stake` if activating or effective, but not if inactive
+    pub stake: u64,
+    // all non-rent lamports, including stake
+    pub usable_lamports: u64,
+    // initialized, deactivating or deactivated
+    pub dedelegated: bool,
+    // self-explanatory
+    pub exists: bool,
+}
+
+impl StakeSummary {
+    pub fn nav(self, other: Self) -> u64 {
+        self.usable_lamports.saturating_add(other.usable_lamports)
+    }
+
+    pub fn excess_lamports(self, other: Self) -> u64 {
+        self.usable_lamports
+            .saturating_add(other.usable_lamports)
+            .saturating_sub(self.stake)
+            .saturating_sub(other.stake)
+    }
+}
+
+pub async fn get_stake_summaries(
     config: &Config,
     stake_account_addresses: &[Pubkey],
-    minimum_pool_balance: u64,
-) -> Result<Vec<(u64, u64)>, Error> {
-    let rent_exempt_reserve = config
-        .program_client
-        .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
-        .await?;
-
+    rent_exempt_reserve: u64,
+    current_epoch: Epoch,
+) -> Result<Vec<StakeSummary>, Error> {
     let stake_accounts = config
         .rpc_client
         .get_multiple_accounts(stake_account_addresses)
         .await?;
 
-    let mut delegations = vec![];
+    let mut summaries = vec![];
     for stake_account in &stake_accounts {
-        let delegation = if let Some(account) = stake_account {
+        let summary = if let Some(account) = stake_account {
             // if this assert ever triggers, multistake or another account change has landed
             // this function should be updated to use real stake account sizes
             // we may be fetching hundreds of accounts here so memoize the rents
@@ -86,25 +122,45 @@ pub async fn get_available_balances(
             );
 
             match bincode::deserialize::<StakeStateV2>(&account.data) {
-                Ok(StakeStateV2::Stake(_, stake, _)) => (
-                    stake.delegation.stake.saturating_sub(minimum_pool_balance),
-                    account
-                        .lamports
-                        .saturating_sub(stake.delegation.stake)
-                        .saturating_sub(rent_exempt_reserve),
-                ),
-                Ok(StakeStateV2::Initialized(_)) => {
-                    (0, account.lamports.saturating_sub(rent_exempt_reserve))
+                // typical stake state. either activating or effective can be "pool stake"
+                Ok(StakeStateV2::Stake(_, Stake { delegation, .. }, _)) => {
+                    let stake = if delegation.activation_epoch <= current_epoch
+                        && delegation.deactivation_epoch >= current_epoch
+                    {
+                        delegation.stake
+                    } else {
+                        0
+                    };
+
+                    StakeSummary {
+                        stake,
+                        usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
+                        dedelegated: delegation.deactivation_epoch != u64::MAX,
+                        exists: true,
+                    }
                 }
+                // impossible for main stake, routine for onramp
+                Ok(StakeStateV2::Initialized(_)) => StakeSummary {
+                    stake: 0,
+                    usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
+                    dedelegated: true,
+                    exists: true,
+                },
                 _ => unreachable!(),
             }
         } else {
-            (0, 0)
+            // possible if onramp never created
+            StakeSummary {
+                stake: 0,
+                usable_lamports: 0,
+                dedelegated: true,
+                exists: false,
+            }
         };
-        delegations.push(delegation);
+        summaries.push(summary);
     }
 
-    Ok(delegations)
+    Ok(summaries)
 }
 
 pub async fn get_token_supplies(
@@ -126,7 +182,8 @@ pub async fn get_token_supplies(
         } else {
             0
         };
-        supplies.push(supply);
+
+        supplies.push(supply.saturating_add(PHANTOM_TOKENS));
     }
 
     Ok(supplies)
@@ -138,7 +195,7 @@ pub async fn create_uninitialized_stake_account_instruction(
     stake_account: &Pubkey,
 ) -> Result<Instruction, Error> {
     let rent_amount = config
-        .program_client
+        .rpc_client
         .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
         .await?;
 

--- a/clients/cli/src/quarantine.rs
+++ b/clients/cli/src/quarantine.rs
@@ -111,51 +111,55 @@ pub async fn get_stake_summaries(
 
     let mut summaries = vec![];
     for stake_account in &stake_accounts {
-        let summary = if let Some(account) = stake_account {
-            // if this assert ever triggers, multistake or another account change has landed
-            // this function should be updated to use real stake account sizes
-            // we may be fetching hundreds of accounts here so memoize the rents
-            assert!(
-                !account.data.is_empty() && account.data.len() != StakeStateV2::size_of(),
-                "StakeStateV2 is no longer canonical, or StakeStateV2::size_of() is no longer 200."
-            );
+        let summary = match stake_account {
+            Some(account) if !account.data.is_empty() => {
+                // if this assert ever triggers, multistake or another account change has landed.
+                // this function should be updated to use real stake account sizes.
+                // we may be fetching hundreds of accounts here so memoize the rents
+                assert_eq!(
+                    account.data.len(),
+                    StakeStateV2::size_of(),
+                    "StakeStateV2 is no longer canonical, or StakeStateV2::size_of() is no longer 200."
+                );
 
-            match bincode::deserialize::<StakeStateV2>(&account.data) {
-                // typical stake state. either activating or effective can be "pool stake"
-                Ok(StakeStateV2::Stake(_, Stake { delegation, .. }, _)) => {
-                    let stake = if delegation.activation_epoch <= current_epoch
-                        && delegation.deactivation_epoch >= current_epoch
-                    {
-                        delegation.stake
-                    } else {
-                        0
-                    };
+                match bincode::deserialize::<StakeStateV2>(&account.data) {
+                    // typical stake state. either activating or effective can be "pool stake"
+                    Ok(StakeStateV2::Stake(_, Stake { delegation, .. }, _)) => {
+                        let stake = if delegation.activation_epoch <= current_epoch
+                            && delegation.deactivation_epoch >= current_epoch
+                        {
+                            delegation.stake
+                        } else {
+                            0
+                        };
 
-                    StakeSummary {
-                        stake,
-                        usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
-                        dedelegated: delegation.deactivation_epoch != u64::MAX,
-                        exists: true,
+                        StakeSummary {
+                            stake,
+                            usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
+                            dedelegated: delegation.deactivation_epoch != u64::MAX,
+                            exists: true,
+                        }
                     }
+                    // impossible for main stake, routine for onramp
+                    Ok(StakeStateV2::Initialized(_)) => StakeSummary {
+                        stake: 0,
+                        usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
+                        dedelegated: true,
+                        exists: true,
+                    },
+                    _ => unreachable!(),
                 }
-                // impossible for main stake, routine for onramp
-                Ok(StakeStateV2::Initialized(_)) => StakeSummary {
-                    stake: 0,
-                    usable_lamports: account.lamports.saturating_sub(rent_exempt_reserve),
-                    dedelegated: true,
-                    exists: true,
-                },
-                _ => unreachable!(),
             }
-        } else {
-            // possible if onramp never created
-            StakeSummary {
+            // impossible for main stake, possible if onramp never created.
+            // we ignore lamports in an uninitialized onramp since we will never use them for math
+            _ => StakeSummary {
                 stake: 0,
                 usable_lamports: 0,
                 dedelegated: true,
                 exists: false,
-            }
+            },
         };
+
         summaries.push(summary);
     }
 

--- a/clients/cli/tests/test.rs
+++ b/clients/cli/tests/test.rs
@@ -19,9 +19,9 @@ use {
     solana_system_interface::{instruction as system_instruction, program as system_program},
     solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
     solana_transaction::Transaction,
-    solana_vote_program::{
-        vote_instruction::{self, CreateVoteAccountConfig},
-        vote_state::{VoteInit, VoteStateV4},
+    solana_vote_interface::{
+        instruction::{self as vote_instruction, CreateVoteAccountConfig},
+        state::{VoteInit, VoteStateV4},
     },
     spl_single_pool::{
         id,


### PR DESCRIPTION
* display locked stake and phantom tokens in line with #582
* display total pool asset value and total excess lamports in line with #601
* show total network value for `DisplayAll` in sol rather than lamports
* display warnings for a dedelegated pool, nonexistent onramp, and potentially valuable replenish
* fix a bug where all `--dry-run` commands claimed to succeed
* remove `spl_token_client` including `ProgramClient`
* replace all uses of `spl_token`, `vote_program`, and `stake_program` with interface crates

most of the meaningful work is in `command_display()`, `get_stake_summaries()`, and `output.rs` changing how `Display` and `DisplayAll` work. the rest of the diff is just consequences of changing `program_client` to `rpc_client`. no functionality (except the simulate bug lol) for any other command changes except a couple errors are slightly more correct

normal example:

```
SPL Single-Validator Stake Pool
  Pool address: H1F5CVVCqXVPHJrU45Ewbu227oBnJFfcm3mtpCYhpn6C
  Vote account address: mrgn6ETrBDM8mjjYN8rbVwFqVwF8z6rtmvGLbdGuVUU
  Net asset value: 1515545211
  Notional token supply: 1227210480
/!\ POOL STAKE IS UNDELEGATED /!\ This validator's vote account may be delinquent or closed!
```

verbose example:

```
SPL Single-Validator Stake Pool
  Pool address: 76bZpzHEad4UUmS1qX57oeb8eeGk3sku8t8WT3vPJ5To
  Vote account address: gangtRyGPTvYWb8K3xS2feJQaCks4iJ7rytFUPtVqSY
  Pool main stake account address: FFGfgLctyaDMXMiGywivnjZQPKqhTC3PnL9iaoA3RANU
  Pool onramp stake account address: 5BsduezBoR8PcWBb8tRYgkKhEhpYozLb7L9Ubk4NmkTE
  Pool mint address: 6ZS7ZVDw91BVAC8gsz3SZBSeVeF2GtXtL2BHK31Kvyjm
  Pool stake authority address: 88cp4RN952zXMbfKdAM7oqGoBeDPVHDtnTtadw6ZfyEn
  Pool mint authority address: 2eTwHCU6V1jYdfieTKDzRgeoM2ktb6g6qviZmqXkfNVn
  Pool MPL authority address: b4iv4TZjpi3FXLNsFQsdYXkkurLcxV9Eztefvk7GBpo
  Net asset value: 1089625308
  Undelegated lamports: 3393326
  Notional token supply: 1000000000
/!\ This pool has 0.003393326 SOL not earning rewards; use `spl-single-pool manage replenish-pool` to delegate it
```

closes #118
closes #543