### PR TITLE
deps: Bump rustls-webpki (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,7 +5742,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5792,7 +5792,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5817,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ audit:
 			--ignore RUSTSEC-2024-0344 \
 			--ignore RUSTSEC-2026-0098 \
 			--ignore RUSTSEC-2026-0099 \
+			--ignore RUSTSEC-2026-0104 \
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
#### Problem

The current version of rustls-webpki has a security advisory (again)

#### Summary of changes

Bump the version, and ignore for earlier versions