### PR TITLE
cli: fix initialize warning

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -131,6 +131,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
     };
 
     let minimum_pool_balance = quarantine::get_minimum_pool_balance(config).await?;
+    let minimum_delegation = config.rpc_client.get_stake_minimum_delegation().await?;
 
     let mut instructions = spl_single_pool::instruction::initialize(
         &spl_single_pool::id(),
@@ -170,7 +171,7 @@ async fn command_initialize(config: &Config, command_config: InitializeCli) -> C
             token_supply: quarantine::PHANTOM_TOKENS,
             main_stake_dedelegated: false,
             onramp_exists: true,
-            minimum_delegation: 0, // only used to warn to replenish
+            minimum_delegation,
             signature,
         },
     ))


### PR DESCRIPTION
initialize prints a `This pool has 0 SOL not earning rewards` warning because of the recent display change, it looked fine to me when i wrote it because the `>` covered it up, but the fix to `>=` revealed its true nature