### PR TITLE
cli: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "spl-single-pool-cli"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "agave-feature-set",
  "bincode",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-single-pool-cli"
-version = "3.0.0"
+version = "4.0.0"
 description = "Solana Program Library Single-Validator Stake Pool Command-line Utility"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/single-pool"


### PR DESCRIPTION
as can be seen on https://crates.io/crates/spl-single-pool-cli, the v4.0.0 release succeeded on crates, but the version bump commit didnt take. this was my mistake, i thought i could do js and cli in parallel since they have no code overlap, but did not fully envision the consequences of my actions

will make a tag/release after this lands