### PR TITLE
Add Setup Environment step to publish workflows

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+
       - name: Compute variables
         id: compute
         shell: bash

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+
       - name: Compute variables
         id: compute
         shell: bash


### PR DESCRIPTION
This PR adds the missing `Setup Environment` step to the `set_env` job of the publish-js and publish-rust workflows so `toml-cli` is available when computing the Solana CLI version. Without it, `make solana-cli-version` resolved to an empty value, which made the Solana install target a malformed URL and fail on a cold cache. The single-pool client's `@solana/*` dependencies are already on their v7 lines, so no dependency changes are needed.