### PR TITLE
audit: Ignore h2 warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ audit:
 			--ignore RUSTSEC-2026-0098 \
 			--ignore RUSTSEC-2026-0099 \
 			--ignore RUSTSEC-2026-0104 \
+			--ignore RUSTSEC-2026-0258 \
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
#### Problem

CI is failing due to a security advisory on the h2 crate.

#### Summary of changes

Ignore the advisory, it's not directly used by the program.